### PR TITLE
chore: link to Luma

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,6 +21,6 @@ description = "BitDevsNBO is a community in Nairobi, Kenya, for those interested
 # Put all your custom variables here
 
 github = "https://github.com/BitDevsNBO/bitdevsnbo"
-meetup = "https://www.meetup.com/bitdevsnbo"
+luma    = "https://lu.ma/bitdevsnbo"
 discord = "https://discord.gg/RQmYSGJeNZ"
 twitter = "https://twitter.com/BitDevsNBO"

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@
             </div>
             <nav class="Header-nav">
                 <a href="/about">About</a>
-                <a href="{{ config.extra.meetup }}" target="_blank" rel="noopener nofollow">Meetup</a>
+                <a href="{{ config.extra.luma }}" target="_blank" rel="noopener nofollow">Luma</a>
                 <a href="{{ config.extra.discord }}" target="_blank" rel="noopener nofollow">Discord</a>
                 <a href="{{ config.extra.twitter }}" target="_blank" rel="noopener nofollow">Twitter</a>
             </nav>


### PR DESCRIPTION
migrate event calendar to Luma and link to it

![image](https://github.com/BitDevsNBO/bitdevsnbo.org/assets/11217077/a98a8f6d-d9fe-408b-886d-ceb734947dbb)

https://lu.ma/bitdevsnbo