### PR TITLE
fix: reorder and clean quicklinks

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -2,7 +2,6 @@ title: 'BitDevsNBO'
 tagline: 'BitDevsNBO is a monthly meetup devoted to the research and development of Bitcoin'
 
 menu:
-  - {name: 'Events', url: '/events'}
-  - {name: 'Luma', url: 'https://lu.ma/bitdevsnbo', external: true}
-  - {name: 'Discord', url: 'https://discord.gg/RQmYSGJeNZ', external: true}
   - {name: 'X', url: 'https://x.com/BitDevsNBO', external: true}
+  - {name: 'Discord', url: 'https://discord.gg/RQmYSGJeNZ', external: true}
+  - {name: 'Luma', url: 'https://lu.ma/bitdevsnbo', external: true}


### PR DESCRIPTION
Previously,
- the "X" link looked like a close website button because of placement
- the "Events" link was dead

Removed dead link and reordered for accessibility

---

**before**
<img width="1298" height="248" alt="image" src="https://github.com/user-attachments/assets/253a1cd1-0fff-4380-bc34-2e1f80d65824" />

**after**

<img width="1298" height="248" alt="image" src="https://github.com/user-attachments/assets/ae71017a-1cc4-4d60-8ca9-994c1ea28b00" />

