### PR TITLE
fix: add XSLT stylesheet to style /feed.xml in browser

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,12 +8,12 @@ future: true # allow posts with future dates
 
 sass:
   sass_dir: assets/css
-  style: :compressed
+  style: "compressed"
 
 # Customise atom feed settings (this is where Jekyll-Feed gets configuration information)
 title: "BitDevsNBO"
 description: "BitDevsNBO is a meetup devoted to the research and development of Bitcoin."
 
 # Leave out some files
-exclude: ['README.md', 'Gemfile', 'Gemfile.lock', '.sass-cache']
+exclude: ['README.md', 'Gemfile', 'Gemfile.lock', '.sass-cache', 'static', 'templates', 'config.toml']
 

--- a/config.toml
+++ b/config.toml
@@ -19,7 +19,7 @@ highlight_code = true
 
 generate_feed = true
 
-feed_filename = "rss.xml"
+feed_filename = "feed.xml"
 
 [extra]
 # Put all your custom variables here

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,28 @@
+---
+layout: none
+---
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="{{ '/feed.xslt.xml' | relative_url }}"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <generator uri="https://jekyllrb.com/" version="{{ jekyll.version }}">Jekyll</generator>
+  <link href="{{ page.url | absolute_url }}" rel="self" type="application/atom+xml"/>
+  <link href="{{ '/' | absolute_url }}" rel="alternate" type="text/html"/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ page.url | absolute_url }}</id>
+  {% if site.title %}<title type="html">{{ site.title | smartify | xml_escape }}</title>{% endif %}
+  {% if site.description %}<subtitle>{{ site.description | xml_escape }}</subtitle>{% endif %}
+  {% for post in site.posts limit: 10 %}
+  <entry>
+    <title type="html">{{ post.title | smartify | xml_escape }}</title>
+    <link href="{{ post.url | absolute_url }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}"/>
+    <published>{{ post.date | date_to_xmlschema }}</published>
+    <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
+    <id>{{ post.id | absolute_url }}</id>
+    <content type="html" xml:base="{{ post.url | absolute_url }}">{{ post.content | xml_escape }}</content>
+    <author>
+      <name>{{ post.author | default: site.author | xml_escape }}</name>
+    </author>
+    {% if post.excerpt %}<summary type="html">{{ post.excerpt | xml_escape }}</summary>{% endif %}
+  </entry>
+  {% endfor %}
+</feed>

--- a/feed.xslt.xml
+++ b/feed.xslt.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:atom="http://www.w3.org/2005/Atom">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <head>
+        <title><xsl:value-of select="atom:feed/atom:title"/> - RSS Feed</title>
+        <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+        <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet"/>
+        <style>
+          body {
+            font-family: 'Source Code Pro', monospace;
+            font-size: 16px;
+            line-height: 1.5;
+            background-color: #FFF;
+            color: #333;
+            margin: 0;
+          }
+          @media (max-width: 1024px) { body { font-size: 14px; } }
+          @media (max-width: 768px)  { body { font-size: 13px; } }
+          @media (max-width: 400px)  { body { font-size: 12px; } }
+          .Site {
+            max-width: 880px;
+            margin: 0 auto;
+            padding: 2rem;
+          }
+          a {
+            color: #FF9900;
+            text-decoration: none;
+          }
+          a:hover {
+            color: rgba(255, 153, 0, 0.8);
+          }
+          .Header {
+            margin-bottom: 0.75rem;
+          }
+          .Header-inner {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+          }
+          .Header-logo {
+            font-size: 2.2rem;
+          }
+          .Header-logo a {
+            color: #333;
+          }
+          .Header-border {
+            opacity: 0.4;
+            margin-top: 0.4rem;
+            overflow: hidden;
+          }
+          h1 {
+            font-size: 1.6rem;
+            margin-top: 3rem;
+            margin-bottom: 1.5rem;
+            font-weight: bold;
+          }
+          p {
+            margin-bottom: 1rem;
+          }
+          .feed-intro {
+            margin: 1rem 0 2rem;
+          }
+          .feed-url {
+            background: #f5f5f5;
+            padding: 0.5rem 1rem;
+            font-size: 0.9rem;
+            margin-bottom: 2rem;
+            word-break: break-all;
+          }
+          .entry {
+            margin-bottom: 1.5rem;
+            padding-bottom: 1.5rem;
+            border-bottom: 1px solid #eee;
+          }
+          .entry-title {
+            font-size: 1.2rem;
+            font-weight: bold;
+            margin-bottom: 0.25rem;
+          }
+          .entry-date {
+            color: #999;
+            font-size: 0.9rem;
+          }
+          .Footer {
+            margin-top: 2rem;
+          }
+          .Footer-border {
+            opacity: 0.4;
+            margin-bottom: 1em;
+            overflow: hidden;
+          }
+          .Footer-inner {
+            display: flex;
+            justify-content: space-between;
+          }
+          .Footer-inner a {
+            color: #333;
+            opacity: 0.4;
+          }
+          .Footer-inner a:hover {
+            color: #FF9900;
+            opacity: 1;
+          }
+        </style>
+      </head>
+      <body>
+        <div class="Site">
+          <header class="Header">
+            <div class="Header-inner">
+              <div class="Header-logo">
+                <a href="/"><xsl:value-of select="atom:feed/atom:title"/></a>
+              </div>
+            </div>
+            <div class="Header-border">==============================================================================================================================================================</div>
+          </header>
+
+          <h1>RSS Feed</h1>
+          <p class="feed-intro">
+            This is the <xsl:value-of select="atom:feed/atom:title"/> Atom feed.
+            Subscribe by copying the URL below into your RSS reader.
+          </p>
+          <div class="feed-url">
+            <xsl:value-of select="atom:feed/atom:link[@rel='self']/@href"/>
+          </div>
+
+          <xsl:for-each select="atom:feed/atom:entry">
+            <div class="entry">
+              <div class="entry-title">
+                <a>
+                  <xsl:attribute name="href">
+                    <xsl:value-of select="atom:link/@href"/>
+                  </xsl:attribute>
+                  <xsl:value-of select="atom:title"/>
+                </a>
+              </div>
+              <div class="entry-date">
+                <xsl:value-of select="substring(atom:published, 0, 11)"/>
+              </div>
+            </div>
+          </xsl:for-each>
+
+          <footer class="Footer">
+            <div class="Footer-border">==============================================================================================================================================================</div>
+            <div class="Footer-inner">
+              <a href="/"><xsl:value-of select="atom:feed/atom:title"/></a>
+            </div>
+          </footer>
+        </div>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>

--- a/static/feed.xslt.xml
+++ b/static/feed.xslt.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:atom="http://www.w3.org/2005/Atom">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <head>
+        <title><xsl:value-of select="atom:feed/atom:title"/> - RSS Feed</title>
+        <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+        <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet"/>
+        <style>
+          body {
+            font-family: 'Source Code Pro', monospace;
+            font-size: 16px;
+            line-height: 1.5;
+            background-color: #FFF;
+            color: #333;
+            margin: 0;
+          }
+          @media (max-width: 1024px) { body { font-size: 14px; } }
+          @media (max-width: 768px)  { body { font-size: 13px; } }
+          @media (max-width: 400px)  { body { font-size: 12px; } }
+          .Site {
+            max-width: 880px;
+            margin: 0 auto;
+            padding: 2rem;
+          }
+          a {
+            color: #FF9900;
+            text-decoration: none;
+          }
+          a:hover {
+            color: rgba(255, 153, 0, 0.8);
+          }
+          .Header {
+            margin-bottom: 0.75rem;
+          }
+          .Header-inner {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+          }
+          .Header-logo {
+            font-size: 2.2rem;
+          }
+          .Header-logo a {
+            color: #333;
+          }
+          .Header-border {
+            opacity: 0.4;
+            margin-top: 0.4rem;
+            overflow: hidden;
+          }
+          h1 {
+            font-size: 1.6rem;
+            margin-top: 3rem;
+            margin-bottom: 1.5rem;
+            font-weight: bold;
+          }
+          p {
+            margin-bottom: 1rem;
+          }
+          .feed-intro {
+            margin: 1rem 0 2rem;
+          }
+          .feed-url {
+            background: #f5f5f5;
+            padding: 0.5rem 1rem;
+            font-size: 0.9rem;
+            margin-bottom: 2rem;
+            word-break: break-all;
+          }
+          .entry {
+            margin-bottom: 1.5rem;
+            padding-bottom: 1.5rem;
+            border-bottom: 1px solid #eee;
+          }
+          .entry-title {
+            font-size: 1.2rem;
+            font-weight: bold;
+            margin-bottom: 0.25rem;
+          }
+          .entry-date {
+            color: #999;
+            font-size: 0.9rem;
+          }
+          .Footer {
+            margin-top: 2rem;
+          }
+          .Footer-border {
+            opacity: 0.4;
+            margin-bottom: 1em;
+            overflow: hidden;
+          }
+          .Footer-inner {
+            display: flex;
+            justify-content: space-between;
+          }
+          .Footer-inner a {
+            color: #333;
+            opacity: 0.4;
+          }
+          .Footer-inner a:hover {
+            color: #FF9900;
+            opacity: 1;
+          }
+        </style>
+      </head>
+      <body>
+        <div class="Site">
+          <header class="Header">
+            <div class="Header-inner">
+              <div class="Header-logo">
+                <a href="/"><xsl:value-of select="atom:feed/atom:title"/></a>
+              </div>
+            </div>
+            <div class="Header-border">==============================================================================================================================================================</div>
+          </header>
+
+          <h1>RSS Feed</h1>
+          <p class="feed-intro">
+            This is the <xsl:value-of select="atom:feed/atom:title"/> Atom feed.
+            Subscribe by copying the URL below into your RSS reader.
+          </p>
+          <div class="feed-url">
+            <xsl:value-of select="atom:feed/atom:link[@rel='self']/@href"/>
+          </div>
+
+          <xsl:for-each select="atom:feed/atom:entry">
+            <div class="entry">
+              <div class="entry-title">
+                <a>
+                  <xsl:attribute name="href">
+                    <xsl:value-of select="atom:link/@href"/>
+                  </xsl:attribute>
+                  <xsl:value-of select="atom:title"/>
+                </a>
+              </div>
+              <div class="entry-date">
+                <xsl:value-of select="substring(atom:published, 0, 11)"/>
+              </div>
+            </div>
+          </xsl:for-each>
+
+          <footer class="Footer">
+            <div class="Footer-border">==============================================================================================================================================================</div>
+            <div class="Footer-inner">
+              <a href="/"><xsl:value-of select="atom:feed/atom:title"/></a>
+            </div>
+          </footer>
+        </div>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/feed.xslt.xml"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ lang }}">
+    <title>{{ config.title }}</title>
+    {% if config.description %}
+    <subtitle>{{ config.description }}</subtitle>
+    {% endif %}
+    <link rel="self" type="application/atom+xml" href="{{ get_url(path=config.feed_filename) }}"/>
+    <link rel="alternate" type="text/html" href="{{ config.base_url | safe }}"/>
+    <generator uri="https://www.getzola.org/">Zola</generator>
+    <updated>{{ last_updated | date(format="%+") }}</updated>
+    <id>{{ get_url(path=config.feed_filename) }}</id>
+    {% for page in pages %}
+    <entry xml:lang="{{ page.lang }}">
+        <title>{{ page.title }}</title>
+        <published>{{ page.date | date(format="%+") }}</published>
+        <updated>{{ page.updated | default(value=page.date) | date(format="%+") }}</updated>
+        <link rel="alternate" type="text/html" href="{{ page.permalink }}"/>
+        <id>{{ page.permalink }}</id>
+        {% if page.authors %}
+        <author>
+            <name>{{ page.authors | join(sep=", ") }}</name>
+        </author>
+        {% endif %}
+        <content type="html">{{ page.content | safe }}</content>
+        {% if page.summary %}
+        <summary type="html">{{ page.summary | safe }}</summary>
+        {% endif %}
+    </entry>
+    {% endfor %}
+</feed>


### PR DESCRIPTION
## Problem
Visiting `/feed.xml` shows raw unstyled XML, poor UX for anyone navigating there directly.

## Fix
- Overrides Jekyll's feed template (`feed.xml`) and Zola's feed template (`templates/atom.xml`) to inject an `<?xml-stylesheet?>` processing instruction
- Adds `feed.xslt.xml` (Jekyll) and `static/feed.xslt.xml` (Zola) — XSLT stylesheets that render the feed as HTML using the site's design tokens
- RSS readers are unaffected; Atom XML content is preserved

Closes #87